### PR TITLE
fix(ui): nothing appears on lists

### DIFF
--- a/ui/update.go
+++ b/ui/update.go
@@ -112,16 +112,10 @@ func (m Model) handleResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	m.width = msg.Width
 	m.height = msg.Height
 	m.help.Width = msg.Width
-
-	switch m.state {
-	case stateInbox:
-		m.emailList.SetSize(msg.Width, msg.Height-3)
-	case stateViewing:
-		m.viewport.Width = msg.Width
-		m.viewport.Height = msg.Height - 7
-	case stateLabels:
-		m.labelList.SetSize(msg.Width, msg.Height-3)
-	}
+	m.emailList.SetSize(msg.Width, msg.Height-3)
+	m.labelList.SetSize(msg.Width, msg.Height-3)
+	m.viewport.Width = msg.Width
+	m.viewport.Height = msg.Height - 7
 	return m, nil
 }
 
@@ -327,7 +321,7 @@ func (m Model) updateReplying(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		quoted := fmt.Sprintf(
 			"\n\n--- Original Message ---\nFrom: %s\nDate: %s\n\n%s",
 			m.replyTo.From, m.replyTo.Date,
-			api.IndentText(m.currentEmail.Body),
+			api.IndentText(m.replyTo.Body),
 		)
 		subject := m.replyTo.Subject
 		if !strings.HasPrefix(strings.ToLower(subject), "re:") {


### PR DESCRIPTION
This pull request makes targeted improvements to the UI update logic, specifically addressing how window resizing is handled and fixing a bug in the reply quoting functionality. The main changes are:

UI resizing logic simplification:

* Simplified the `handleResize` method in `ui/update.go` by removing the switch statement and consistently resizing both `emailList` and `labelList`, ensuring they always match the window size. This reduces complexity and potential bugs when switching between states.

Bug fix in reply quoting:

* Fixed a bug in the reply functionality so that the quoted text in a reply now correctly uses the body of the email being replied to (`m.replyTo.Body`) instead of the currently viewed email (`m.currentEmail.Body`). This ensures the reply includes the intended original message.

Closes #9 