### PR TITLE
Show all inbox categories by default

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	MaxConcurrent    int    `toml:"max_concurrent"`     // default: 5, range [1,20]
 	CacheMaxSize     int    `toml:"cache_max_size"`     // default: 500
 	LogLevel         string `toml:"log_level"`          // default: "INFO"
-	InboxQuery       string `toml:"inbox_query"`        // default: "in:inbox category:primary"
+	InboxQuery       string `toml:"inbox_query"`        // default: "in:inbox"
 	CredentialsPath  string `toml:"-"`                  // from env GMAIL_TUI_CREDENTIALS
 }
 
@@ -32,7 +32,7 @@ func defaultConfig() *Config {
 		MaxConcurrent:    5,
 		CacheMaxSize:     500,
 		LogLevel:         "INFO",
-		InboxQuery:       "in:inbox category:primary",
+		InboxQuery:       "in:inbox",
 	}
 }
 
@@ -139,7 +139,7 @@ func (c *Config) validate() {
 		c.SearchMaxResults = clamp(c.SearchMaxResults, 1, 500)
 	}
 	if strings.TrimSpace(c.InboxQuery) == "" {
-		c.InboxQuery = "in:inbox category:primary"
+		c.InboxQuery = "in:inbox"
 	}
 	if c.CacheMaxSize < 10 || c.CacheMaxSize > 10000 {
 		slog.Warn("cache_max_size out of range [10,10000], clamping",

--- a/api/config_test.go
+++ b/api/config_test.go
@@ -24,6 +24,14 @@ func TestLoadConfigDefaults(t *testing.T) {
 	}
 }
 
+func TestDefaultInboxQueryIncludesEveryInboxCategory(t *testing.T) {
+	t.Parallel()
+
+	if got := defaultConfig().InboxQuery; got != "in:inbox" {
+		t.Fatalf("default InboxQuery = %q, want %q", got, "in:inbox")
+	}
+}
+
 func TestLoadConfigTOMLOverride(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)
@@ -118,6 +126,18 @@ func TestConfigValidateClampsRanges(t *testing.T) {
 		if !strings.Contains(logs.String(), field) {
 			t.Fatalf("expected warning for %s in %q", field, logs.String())
 		}
+	}
+}
+
+func TestConfigValidateEmptyInboxQueryUsesEveryInboxCategory(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.InboxQuery = "  "
+	cfg.validate()
+
+	if cfg.InboxQuery != "in:inbox" {
+		t.Fatalf("InboxQuery = %q, want %q", cfg.InboxQuery, "in:inbox")
 	}
 }
 


### PR DESCRIPTION
## Problem

The default inbox query includes `category:primary`. Gmail accounts whose inbox messages are in other categories can therefore show an empty inbox even though search finds those messages.

## Change

Use `in:inbox` for the built-in default and empty-query fallback. Explicit `inbox_query` configuration remains unchanged.

## Verification

- `go test ./...` in the project Linux builder
- Regression coverage for the built-in default and empty-query fallback
- Tested with running locally against my inbox. Messages appeared after the fix