### PR TITLE
feat: unread-only inbox toggle

### DIFF
--- a/ui/keys.go
+++ b/ui/keys.go
@@ -15,6 +15,7 @@ type keyMap struct {
 	Search             key.Binding
 	Labels             key.Binding
 	ToggleRead         key.Binding
+	ToggleUnreadFilter key.Binding
 	Quit               key.Binding
 	Send               key.Binding
 	NextInput          key.Binding
@@ -32,11 +33,11 @@ type keyMap struct {
 func (k keyMap) ShortHelp() []key.Binding {
 	return []key.Binding{k.ShowHelp, k.Compose, k.Search, k.Labels, k.Quit}
 }
-
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Compose, k.Reply, k.Search, k.Labels},
 		{k.Delete, k.Archive, k.ToggleRead, k.Refresh},
+		{k.ToggleUnreadFilter},
 		{k.Back, k.Quit},
 		{k.Send, k.NextInput, k.PrevInput},
 		{k.AddAttachment, k.RemoveAttachment, k.DownloadAttachment},
@@ -56,6 +57,7 @@ var keys = keyMap{
 	Search:             key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search")),
 	Labels:             key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "labels")),
 	ToggleRead:         key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "mark read/unread")),
+	ToggleUnreadFilter: key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "all/unread only")),
 	Quit:               key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
 	Send:               key.NewBinding(key.WithKeys("ctrl+s"), key.WithHelp("ctrl+s", "send")),
 	NextInput:          key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "next field")),

--- a/ui/model.go
+++ b/ui/model.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"os"
+	"strings"
 
 	"github.com/rdx40/gmail-tui/api"
 
@@ -133,7 +134,9 @@ type Model struct {
 	height int
 
 	// Inbox
-	emailList list.Model
+	emailList   list.Model
+	unreadOnly  bool // true: filter inbox to unread only
+	listIsInbox bool // true: emailList shows the inbox; false: search/label results
 
 	// Pagination
 	pageToken    string   // token that fetches the NEXT page ("" = no more)
@@ -237,6 +240,7 @@ func New(client api.ClientInterface, cfg *api.Config) Model {
 		labelList:   ll,
 		attachInput: newTextInput("Path to attachment...", 300),
 		currentPage: 1,
+		listIsInbox: true,
 		noStyle:     noStyle,
 	}
 }
@@ -245,12 +249,22 @@ func New(client api.ClientInterface, cfg *api.Config) Model {
 func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		m.spinner.Tick,
-		fetchInbox(m.client, m.config.InboxQuery, int64(m.config.MaxResults)),
+		fetchInbox(m.client, m.effectiveInboxQuery(), int64(m.config.MaxResults)),
 		fetchUserProfileCmd(m.client),
 	)
 }
 
 // ---------- helpers ----------
+
+// effectiveInboxQuery returns the configured inbox query, narrowed to unread
+// messages when the unread-only filter is active.
+func (m Model) effectiveInboxQuery() string {
+	q := m.config.InboxQuery
+	if m.unreadOnly {
+		q = strings.TrimSpace(q) + " is:unread"
+	}
+	return q
+}
 
 func newTextInput(placeholder string, charLimit int) textinput.Model {
 	ti := textinput.New()
@@ -275,6 +289,17 @@ func emailsToItems(emails []api.Email) []list.Item {
 		items[i] = emailItem{email: e}
 	}
 	return items
+}
+
+// listEmails extracts the emails backing the current list items.
+func listEmails(items []list.Item) []api.Email {
+	emails := make([]api.Email, 0, len(items))
+	for _, item := range items {
+		if ei, ok := item.(emailItem); ok {
+			emails = append(emails, ei.email)
+		}
+	}
+	return emails
 }
 
 // labelsToItems converts a slice of labels to list items.

--- a/ui/update.go
+++ b/ui/update.go
@@ -27,12 +27,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case inboxLoadedMsg:
 		m.emailList.SetItems(emailsToItems(msg.emails))
-		m.emailList.Title = inboxTitle(msg.emails)
+		m.emailList.Title = inboxTitle(msg.emails, m.unreadOnly)
 		m.totalFetched = len(msg.emails)
 		m.pageToken = msg.nextToken
 		m.currentToken = ""
 		m.pageHistory = nil
 		m.currentPage = 1
+		m.listIsInbox = true
 		m.state = stateInbox
 		return m, nil
 
@@ -63,7 +64,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case emailSentMsg:
 		m.state = stateLoading
 		m.statusMessage = "Email sent!"
-		return m, tea.Batch(m.spinner.Tick, fetchInbox(m.client, m.config.InboxQuery, int64(m.config.MaxResults)), clearStatusAfter(3*time.Second))
+		return m, tea.Batch(m.spinner.Tick, fetchInbox(m.client, m.effectiveInboxQuery(), int64(m.config.MaxResults)), clearStatusAfter(3*time.Second))
 
 	case emailDeletedMsg:
 		m = m.removeListedEmail(msg.id)
@@ -76,16 +77,34 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, clearStatusAfter(3 * time.Second)
 
 	case readToggledMsg:
-		items := m.emailList.Items()
-		for i, item := range items {
-			if ei, ok := item.(emailItem); ok && ei.email.ID == msg.id {
-				ei.email.IsUnread = msg.isUnread
-				m.emailList.SetItem(i, ei)
-				break
+		if m.listIsInbox && m.unreadOnly && !msg.isUnread {
+			// Now-read email no longer matches the unread-only filter; drop it
+			// from the list without forcing a viewing→inbox state change.
+			for i, item := range m.emailList.Items() {
+				if ei, ok := item.(emailItem); ok && ei.email.ID == msg.id {
+					m.emailList.RemoveItem(i)
+					if m.totalFetched > 0 {
+						m.totalFetched--
+					}
+					break
+				}
+			}
+		} else {
+			for i, item := range m.emailList.Items() {
+				if ei, ok := item.(emailItem); ok && ei.email.ID == msg.id {
+					ei.email.IsUnread = msg.isUnread
+					m.emailList.SetItem(i, ei)
+					break
+				}
 			}
 		}
 		if m.currentEmail != nil && m.currentEmail.ID == msg.id {
 			m.currentEmail.IsUnread = msg.isUnread
+		}
+		// Only recompute the inbox title for an active inbox listing; search
+		// and label results keep their own title.
+		if m.listIsInbox {
+			m.emailList.Title = inboxTitle(listEmails(m.emailList.Items()), m.unreadOnly)
 		}
 		action := "marked as read"
 		if msg.isUnread {
@@ -109,7 +128,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.currentToken = ""
 		m.pageHistory = nil
 		m.currentPage = 1
-		m.totalFetched = len(msg.emails)
+		m.listIsInbox = false
 		m.state = stateInbox
 		if len(msg.emails) == 0 && msg.query != "" {
 			m.statusMessage = fmt.Sprintf("No results found for: %s", msg.query)
@@ -258,10 +277,18 @@ func (m Model) updateInbox(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if ei, ok := m.emailList.SelectedItem().(emailItem); ok {
 			return m, archiveEmailCmd(m.client, ei.email.ID)
 		}
-
 	case key.Matches(msg, keys.Refresh):
 		m.state = stateLoading
-		return m, tea.Batch(m.spinner.Tick, fetchInbox(m.client, m.config.InboxQuery, int64(m.config.MaxResults)))
+		return m, tea.Batch(m.spinner.Tick, fetchInbox(m.client, m.effectiveInboxQuery(), int64(m.config.MaxResults)))
+
+	case key.Matches(msg, keys.ToggleUnreadFilter):
+		m.unreadOnly = !m.unreadOnly
+		m.currentPage = 1
+		m.pageHistory = nil
+		m.pageToken = ""
+		m.currentToken = ""
+		m.state = stateLoading
+		return m, tea.Batch(m.spinner.Tick, fetchInbox(m.client, m.effectiveInboxQuery(), int64(m.config.MaxResults)))
 
 	case key.Matches(msg, keys.NextPage):
 		if m.pageToken == "" {
@@ -272,7 +299,7 @@ func (m Model) updateInbox(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.currentToken = m.pageToken
 		m.currentPage++
 		m.state = stateLoading
-		return m, tea.Batch(m.spinner.Tick, fetchNextPageCmd(m.client, m.config.InboxQuery, int64(m.config.MaxResults), m.pageToken))
+		return m, tea.Batch(m.spinner.Tick, fetchNextPageCmd(m.client, m.effectiveInboxQuery(), int64(m.config.MaxResults), m.pageToken))
 
 	case key.Matches(msg, keys.PrevPage):
 		if len(m.pageHistory) == 0 {
@@ -283,7 +310,8 @@ func (m Model) updateInbox(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.currentToken = last
 		m.currentPage--
 		m.state = stateLoading
-		return m, tea.Batch(m.spinner.Tick, fetchNextPageCmd(m.client, m.config.InboxQuery, int64(m.config.MaxResults), last))
+		return m, tea.Batch(m.spinner.Tick, fetchNextPageCmd(m.client, m.effectiveInboxQuery(), int64(m.config.MaxResults), last))
+
 	}
 
 	var cmd tea.Cmd
@@ -539,17 +567,24 @@ func (m Model) updateLabels(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // ---------- sub-handlers ----------
 
 // inboxTitle renders the inbox list title with an unread count when nonzero.
-func inboxTitle(emails []api.Email) string {
+// When unreadOnly is true, a "(unread only)" suffix is appended.
+func inboxTitle(emails []api.Email, unreadOnly bool) string {
 	unread := 0
 	for _, e := range emails {
 		if e.IsUnread {
 			unread++
 		}
 	}
+	var title string
 	if unread == 0 {
-		return "Inbox"
+		title = "Inbox"
+	} else {
+		title = fmt.Sprintf("Inbox (%d unread)", unread)
 	}
-	return fmt.Sprintf("Inbox (%d unread)", unread)
+	if unreadOnly {
+		title += " — unread only"
+	}
+	return title
 }
 
 // removeListedEmail drops an email from the list (after delete/archive) and

--- a/ui/update_test.go
+++ b/ui/update_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rdx40/gmail-tui/api"
 
+	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -290,6 +291,7 @@ type MockClient struct {
 	pageEmails       []api.Email
 	pageNextToken    string
 	pageErr          error
+	lastQuery        string
 	cacheSize        int
 	hasSendScope     bool
 	lastSentSubject  string
@@ -304,7 +306,8 @@ func (m *MockClient) FetchInbox(string, int64) ([]api.Email, error) {
 	return m.inboxEmails, m.inboxErr
 }
 
-func (m *MockClient) FetchInboxPage(string, int64, string) ([]api.Email, string, error) {
+func (m *MockClient) FetchInboxPage(query string, _ int64, _ string) ([]api.Email, string, error) {
+	m.lastQuery = query
 	return m.pageEmails, m.pageNextToken, m.pageErr
 }
 
@@ -482,11 +485,218 @@ func TestReadToggleUpdatesCurrentEmail(t *testing.T) {
 	}
 }
 
+func TestReadToggleUnreadOnlyRemovesReadItem(t *testing.T) {
+	t.Parallel()
+
+	model := newTestModel(&MockClient{})
+	model.state = stateInbox
+	model.unreadOnly = true
+	model.totalFetched = 2
+	model.emailList.SetItems(emailsToItems([]api.Email{
+		{ID: "a", IsUnread: true},
+		{ID: "b", IsUnread: true},
+	}))
+
+	// Mark "a" as read: it must leave the unread-only list.
+	updated, _ := model.Update(readToggledMsg{id: "a", isUnread: false})
+	m := updated.(Model)
+
+	if m.totalFetched != 1 {
+		t.Fatalf("totalFetched = %d, want 1", m.totalFetched)
+	}
+	ids := listEmailIDs(m.emailList.Items())
+	if len(ids) != 1 || ids[0] != "b" {
+		t.Fatalf("list items = %v, want [b]", ids)
+	}
+	if strings.Contains(m.emailList.Title, "2 unread") {
+		t.Fatalf("title = %q, should not show 2 unread", m.emailList.Title)
+	}
+}
+
+func TestReadToggleUnreadOnlyKeepsUnreadItem(t *testing.T) {
+	t.Parallel()
+
+	model := newTestModel(&MockClient{})
+	model.state = stateInbox
+	model.unreadOnly = true
+	model.totalFetched = 1
+	model.emailList.SetItems(emailsToItems([]api.Email{{ID: "a", IsUnread: false}}))
+
+	// Mark "a" as unread: it stays in the list (now matches the filter).
+	updated, _ := model.Update(readToggledMsg{id: "a", isUnread: true})
+	m := updated.(Model)
+
+	if m.totalFetched != 1 {
+		t.Fatalf("totalFetched = %d, want 1", m.totalFetched)
+	}
+	ids := listEmailIDs(m.emailList.Items())
+	if len(ids) != 1 || ids[0] != "a" {
+		t.Fatalf("list items = %v, want [a]", ids)
+	}
+}
+
+func TestReadToggleAllModeUpdatesInPlace(t *testing.T) {
+	t.Parallel()
+
+	model := newTestModel(&MockClient{})
+	model.state = stateInbox
+	model.unreadOnly = false
+	model.totalFetched = 1
+	model.emailList.SetItems(emailsToItems([]api.Email{{ID: "a", IsUnread: true}}))
+
+	// Mark "a" as read in all-messages mode: item stays, IsUnread flips.
+	updated, _ := model.Update(readToggledMsg{id: "a", isUnread: false})
+	m := updated.(Model)
+
+	if m.totalFetched != 1 {
+		t.Fatalf("totalFetched = %d, want 1", m.totalFetched)
+	}
+	ids := listEmailIDs(m.emailList.Items())
+	if len(ids) != 1 || ids[0] != "a" {
+		t.Fatalf("list items = %v, want [a]", ids)
+	}
+}
+
+func TestReadToggleSearchResultsNotAffectedByUnreadOnly(t *testing.T) {
+	t.Parallel()
+
+	model := newTestModel(&MockClient{})
+	model.state = stateInbox
+	model.unreadOnly = true
+	model.listIsInbox = false // simulates Search/Label results in stateInbox
+	model.totalFetched = 1
+	model.emailList.SetItems(emailsToItems([]api.Email{{ID: "a", IsUnread: true}}))
+	model.emailList.Title = "Search: foo"
+
+	// Mark "a" as read: unread-only filter must NOT remove it from search
+	// results, and the title must stay "Search: foo".
+	updated, _ := model.Update(readToggledMsg{id: "a", isUnread: false})
+	m := updated.(Model)
+
+	if m.totalFetched != 1 {
+		t.Fatalf("totalFetched = %d, want 1 (search result must not be removed)", m.totalFetched)
+	}
+	ids := listEmailIDs(m.emailList.Items())
+	if len(ids) != 1 || ids[0] != "a" {
+		t.Fatalf("list items = %v, want [a]", ids)
+	}
+	if m.emailList.Title != "Search: foo" {
+		t.Fatalf("title = %q, want %q", m.emailList.Title, "Search: foo")
+	}
+}
+
+func TestRefreshDoesNotToggleUnreadOnly(t *testing.T) {
+	t.Parallel()
+
+	mc := &MockClient{pageEmails: []api.Email{{ID: "1"}}}
+
+	// unreadOnly=false: R must fetch without flipping the filter.
+	model := newTestModel(mc)
+	model.state = stateInbox
+	model.unreadOnly = false
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
+	m := updated.(Model)
+	if m.unreadOnly {
+		t.Fatal("R flipped unreadOnly to true; refresh must not toggle")
+	}
+	if m.state != stateLoading {
+		t.Fatalf("state = %v, want stateLoading", m.state)
+	}
+	msg := cmd()
+	if _, ok := msg.(tea.BatchMsg); !ok {
+		t.Fatalf("expected tea.BatchMsg from refresh, got %T", msg)
+	}
+
+	// unreadOnly=true: R must fetch and keep the filter on.
+	model2 := newTestModel(mc)
+	model2.state = stateInbox
+	model2.unreadOnly = true
+
+	updated2, _ := model2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
+	m2 := updated2.(Model)
+	if !m2.unreadOnly {
+		t.Fatal("R flipped unreadOnly to false; refresh must not toggle")
+	}
+}
+
+// listEmailIDs returns the email IDs backing the list items, for assertions.
+func listEmailIDs(items []list.Item) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		if ei, ok := item.(emailItem); ok {
+			ids = append(ids, ei.email.ID)
+		}
+	}
+	return ids
+}
+
 func TestTruncateMultibyteSafe(t *testing.T) {
 	t.Parallel()
 
 	got := truncate("héllo wörld émails über", 10)
 	if !strings.HasSuffix(got, "...") || len([]rune(got)) != 10 {
 		t.Fatalf("truncate = %q, want 10 runes ending in ...", got)
+	}
+}
+
+func TestToggleUnreadFilter(t *testing.T) {
+	t.Parallel()
+
+	mc := &MockClient{pageEmails: []api.Email{{ID: "1", IsUnread: true}}}
+	model := newTestModel(mc)
+	model.state = stateInbox
+
+	// Press "u": flips to unread-only and starts a loading fetch.
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	m := updated.(Model)
+	if !m.unreadOnly {
+		t.Fatal("unreadOnly should be true after toggle")
+	}
+	if m.state != stateLoading {
+		t.Fatalf("state = %v, want stateLoading", m.state)
+	}
+	if m.currentPage != 1 || m.pageToken != "" || len(m.pageHistory) != 0 {
+		t.Fatalf("pagination not reset: page=%d token=%q history=%v", m.currentPage, m.pageToken, m.pageHistory)
+	}
+
+	// The fetch command must query with is:unread appended.
+	// tea.Batch wraps the spinner tick and the fetch; find the inbox load.
+	var loadMsg inboxLoadedMsg
+	found := false
+	switch msg := cmd().(type) {
+	case tea.BatchMsg:
+		for _, c := range msg {
+			if c == nil {
+				continue
+			}
+			if lm, ok := c().(inboxLoadedMsg); ok {
+				loadMsg, found = lm, true
+				break
+			}
+		}
+	case inboxLoadedMsg:
+		loadMsg, found = msg, true
+	}
+	if !found {
+		t.Fatal("expected inboxLoadedMsg from batched commands")
+	}
+	if !strings.Contains(mc.lastQuery, "is:unread") {
+		t.Fatalf("query = %q, want it to contain is:unread", mc.lastQuery)
+	}
+	_ = loadMsg
+
+	// Loaded title reflects the unread-only filter.
+	updated, _ = m.Update(inboxLoadedMsg{emails: mc.pageEmails})
+	m = updated.(Model)
+	if !strings.Contains(m.emailList.Title, "unread only") {
+		t.Fatalf("title = %q, want unread-only suffix", m.emailList.Title)
+	}
+
+	// Press "u" again: flips back to all messages.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	m = updated.(Model)
+	if m.unreadOnly {
+		t.Fatal("unreadOnly should be false after second toggle")
 	}
 }

--- a/ui/view.go
+++ b/ui/view.go
@@ -78,7 +78,7 @@ func (m Model) inboxView() string {
 	if m.totalFetched > 0 {
 		pageInfo = fmt.Sprintf("Page %d • %d emails", m.currentPage, m.totalFetched)
 	}
-	help := fmt.Sprintf("\n[c] compose • [d] delete • [a] archive • [m] read/unread • [l] labels • [/] search • [R] refresh • [n/p] page • [?] help • [q] quit  %s\n", pageInfo)
+	help := fmt.Sprintf("\n[c] compose • [d] delete • [a] archive • [m] read/unread • [u] all/unread • [l] labels • [/] search • [R] refresh • [n/p] page • [?] help • [q] quit  %s\n", pageInfo)
 	return m.emailList.View() + m.statusBar() + help
 }
 


### PR DESCRIPTION
## Summary

Add a `u` key toggle in the inbox view to switch between all messages and unread-only.

- When active, the inbox query appends `is:unread`; the list title shows an unread-only suffix.
- Marking an email read (`m`) while in unread-only mode removes it from the filtered list and decrements the count.
- The removal and title recompute are gated on an active inbox listing (`listIsInbox`), so search and label results are never affected.
- Pagination state resets on toggle.
- Refresh (`R`) remains a separate key that refetches without toggling the filter.

## Testing
- `go test -race -count=1 ./...` passes (api + ui).
- `go build`, `go vet`, `gofmt` clean.
- Regression tests: toggle flip/query/title, read-removal in unread-only, read keeps in all-mode, search results unaffected by unread-only, refresh does not toggle unread-only.